### PR TITLE
➕ Adding dependencies needed by heroku local web.

### DIFF
--- a/back-end/node_modules/ts-node/node_modules/.bin/tsc
+++ b/back-end/node_modules/ts-node/node_modules/.bin/tsc
@@ -6,10 +6,10 @@ case `uname` in
 esac
 
 if [ -x "$basedir/node" ]; then
-  "$basedir/node"  "$basedir/../../../../../node_modules/typescript/bin/tsc" "$@"
+  "$basedir/node"  "$basedir/../../../typescript/bin/tsc" "$@"
   ret=$?
 else 
-  node  "$basedir/../../../../../node_modules/typescript/bin/tsc" "$@"
+  node  "$basedir/../../../typescript/bin/tsc" "$@"
   ret=$?
 fi
 exit $ret

--- a/back-end/node_modules/ts-node/node_modules/.bin/tsc.cmd
+++ b/back-end/node_modules/ts-node/node_modules/.bin/tsc.cmd
@@ -1,7 +1,7 @@
 @IF EXIST "%~dp0\node.exe" (
-  "%~dp0\node.exe"  "%~dp0\..\..\..\..\..\node_modules\typescript\bin\tsc" %*
+  "%~dp0\node.exe"  "%~dp0\..\..\..\typescript\bin\tsc" %*
 ) ELSE (
   @SETLOCAL
   @SET PATHEXT=%PATHEXT:;.JS;=;%
-  node  "%~dp0\..\..\..\..\..\node_modules\typescript\bin\tsc" %*
+  node  "%~dp0\..\..\..\typescript\bin\tsc" %*
 )

--- a/back-end/node_modules/ts-node/node_modules/.bin/tsserver
+++ b/back-end/node_modules/ts-node/node_modules/.bin/tsserver
@@ -6,10 +6,10 @@ case `uname` in
 esac
 
 if [ -x "$basedir/node" ]; then
-  "$basedir/node"  "$basedir/../../../../../node_modules/typescript/bin/tsserver" "$@"
+  "$basedir/node"  "$basedir/../../../typescript/bin/tsserver" "$@"
   ret=$?
 else 
-  node  "$basedir/../../../../../node_modules/typescript/bin/tsserver" "$@"
+  node  "$basedir/../../../typescript/bin/tsserver" "$@"
   ret=$?
 fi
 exit $ret

--- a/back-end/node_modules/ts-node/node_modules/.bin/tsserver.cmd
+++ b/back-end/node_modules/ts-node/node_modules/.bin/tsserver.cmd
@@ -1,7 +1,7 @@
 @IF EXIST "%~dp0\node.exe" (
-  "%~dp0\node.exe"  "%~dp0\..\..\..\..\..\node_modules\typescript\bin\tsserver" %*
+  "%~dp0\node.exe"  "%~dp0\..\..\..\typescript\bin\tsserver" %*
 ) ELSE (
   @SETLOCAL
   @SET PATHEXT=%PATHEXT:;.JS;=;%
-  node  "%~dp0\..\..\..\..\..\node_modules\typescript\bin\tsserver" %*
+  node  "%~dp0\..\..\..\typescript\bin\tsserver" %*
 )

--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -13,7 +13,8 @@
         "cors": "^2.8.5",
         "express": "^4.18.1",
         "pg": "^8.7.3",
-        "ts-node": "^10.7.0"
+        "ts-node": "^10.7.0",
+        "typescript": "^4.7.3"
       },
       "devDependencies": {
         "@types/jest": "^27.5.1",
@@ -5252,10 +5253,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-      "peer": true,
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9487,10 +9487,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-      "peer": true
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -16,7 +16,8 @@
     "cors": "^2.8.5",
     "express": "^4.18.1",
     "pg": "^8.7.3",
-    "ts-node": "^10.7.0"
+    "ts-node": "^10.7.0",
+    "typescript": "^4.7.3"
   },
   "repository": "https://git.heroku.com/gym-king.git",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13057,6 +13057,11 @@ typescript@^4.1.3:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
+typescript@^4.7.3:
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
+  integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
+
 typescript@~4.5.2:
   version "4.5.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz"


### PR DESCRIPTION
- Previous commits broke the yarn start:api command.
- This is because of the yarn dependencies missing from the heroku git repo.