### PR TITLE
🚧 add generic build for nx build --affected workflow

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -49,6 +49,7 @@
   "scripts": {
     "serve:prod": "env-cmd -f .env.production react-scripts start",
     "serve:dev": "env-cmd -f .env.development react-scripts start",
+    "build": "yarn nx build:ios && yarn nx build:android",
     "build:ios": " ionic cap build ios env-cmd -f .env.production && echo y | npx --silent trapeze run trapeze.yml",
     "build:android": " ionic cap build android env-cmd -f .env.production && echo y | npx --silent trapeze run trapeze.yml",
     "test": "env-cmd -f .env.development react-scripts  test --transformIgnorePatterns --watchAll=false",


### PR DESCRIPTION
This PR adds the build testaffected back into the automated workflow 